### PR TITLE
Plaintext ballot field compatibility

### DIFF
--- a/src/electionguard/ballot/decrypt.ts
+++ b/src/electionguard/ballot/decrypt.ts
@@ -94,7 +94,6 @@ function decryptAndVerifySelection(
 
   return new PlaintextSelection(
     selection.selectionId,
-    selection.sequenceOrder,
     decryption,
     selection.isPlaceholderSelection,
     undefined

--- a/src/electionguard/ballot/decrypt.ts
+++ b/src/electionguard/ballot/decrypt.ts
@@ -65,7 +65,6 @@ function decryptAndVerifyContest(
 
   return new PlaintextContest(
     contest.contestId,
-    contest.sequenceOrder,
     pSelectionsWithoutPlaceholders
   );
 }

--- a/src/electionguard/ballot/encrypt-async.ts
+++ b/src/electionguard/ballot/encrypt-async.ts
@@ -184,17 +184,17 @@ export class AsyncBallotEncryptor {
     const sequenceOrder = this.sequenceOrderMap.get(contest.contestId);
     const manifestContestDesc = this.manifestContests.get(contest.contestId);
 
-    if (sequenceOrder !== contest.sequenceOrder) {
-      log.errorAndThrow(
-        'encrypt-async',
-        `unexpected seequence order: ${sequenceOrder} vs. ${contest.sequenceOrder}`
-      );
-    }
-
     if (manifestContestDesc === undefined || sequenceOrder === undefined) {
       log.errorAndThrow(
         'encrypt-async',
         `unexpected absence of a ManifestContestDescription for ${contest.contestId}`
+      );
+    }
+
+    if (sequenceOrder !== manifestContestDesc.sequenceOrder) {
+      log.warn(
+        'encrypt-async',
+        `unexpected seequence order: ${sequenceOrder} vs. ${manifestContestDesc.sequenceOrder}`
       );
     }
 
@@ -225,10 +225,10 @@ export class AsyncBallotEncryptor {
     // `encrypting contest ${contest.contestId}, sequence #${sequenceOrder}`
     // );
 
-    if (sequenceOrder !== contest.sequenceOrder) {
+    if (sequenceOrder !== manifestContestDesc.sequenceOrder) {
       log.errorAndThrow(
         'encrypt-async.encryptHelper',
-        `wrong sequence number: ${contest.sequenceOrder} vs. ${sequenceOrder}`
+        `wrong sequence number: ${manifestContestDesc.sequenceOrder} vs. ${sequenceOrder}`
       );
     }
 

--- a/src/electionguard/ballot/encrypt.ts
+++ b/src/electionguard/ballot/encrypt.ts
@@ -121,11 +121,7 @@ function contestFrom(mcontest: ManifestContestDescription): PlaintextContest {
   const selections = mcontest.selections.map(it =>
     selectionFrom(it.selectionId, false, false)
   );
-  return new PlaintextContest(
-    mcontest.contestId,
-    mcontest.sequenceOrder,
-    selections
-  );
+  return new PlaintextContest(mcontest.contestId, selections);
 }
 
 /**
@@ -268,7 +264,7 @@ export function encryptContest(
 
   const encryptedContest = new CiphertextContest(
     contest.contestId,
-    contest.sequenceOrder,
+    contestDescription.sequenceOrder,
     contestDescription.cryptoHashElement,
     encryptedSelections,
     ciphertextAccumulation,

--- a/src/electionguard/ballot/json.ts
+++ b/src/electionguard/ballot/json.ts
@@ -1075,23 +1075,14 @@ export class BallotCodecs {
     const plaintextContestDecoder: D.Decoder<unknown, PlaintextContest> = pipe(
       D.struct({
         object_id: D.string,
-        sequence_order: D.number,
         ballot_selections: D.array(plaintextSelectionDecoder),
       }),
-      D.map(
-        s =>
-          new PlaintextContest(
-            s.object_id,
-            s.sequence_order,
-            s.ballot_selections
-          )
-      )
+      D.map(s => new PlaintextContest(s.object_id, s.ballot_selections))
     );
 
     const plaintextContestEncoder: E.Encoder<unknown, PlaintextContest> = {
       encode: input => ({
         object_id: input.contestId,
-        sequence_order: input.sequenceOrder,
         ballot_selections: input.selections.map(
           plaintextSelectionEncoder.encode
         ),

--- a/src/electionguard/ballot/plaintext-ballot.ts
+++ b/src/electionguard/ballot/plaintext-ballot.ts
@@ -1,8 +1,6 @@
 import {
   ElectionObjectBase,
-  matchingArraysOfOrderedElectionObjects,
   matchingArraysOfAnyElectionObjects,
-  OrderedObjectBase,
 } from './election-object-base';
 
 /**
@@ -25,16 +23,15 @@ export class PlaintextBallot implements ElectionObjectBase {
       other instanceof PlaintextBallot &&
       other.ballotId === this.ballotId &&
       other.ballotStyleId === this.ballotStyleId &&
-      matchingArraysOfOrderedElectionObjects(other.contests, this.contests)
+      matchingArraysOfAnyElectionObjects(other.contests, this.contests)
     );
   }
 }
 
 /** The plaintext representation of a voter's selections for one contest. */
-export class PlaintextContest implements OrderedObjectBase {
+export class PlaintextContest implements ElectionObjectBase {
   constructor(
     readonly contestId: string, // matches ContestDescription.contestId
-    readonly sequenceOrder: number,
     readonly selections: Array<PlaintextSelection>
   ) {}
 
@@ -46,7 +43,6 @@ export class PlaintextContest implements OrderedObjectBase {
     return (
       other instanceof PlaintextContest &&
       other.contestId === this.contestId &&
-      other.sequenceOrder === this.sequenceOrder &&
       matchingArraysOfAnyElectionObjects(other.selections, this.selections)
     );
   }

--- a/src/electionguard/ballot/plaintext-ballot.ts
+++ b/src/electionguard/ballot/plaintext-ballot.ts
@@ -1,6 +1,7 @@
 import {
   ElectionObjectBase,
   matchingArraysOfOrderedElectionObjects,
+  matchingArraysOfAnyElectionObjects,
   OrderedObjectBase,
 } from './election-object-base';
 
@@ -46,19 +47,18 @@ export class PlaintextContest implements OrderedObjectBase {
       other instanceof PlaintextContest &&
       other.contestId === this.contestId &&
       other.sequenceOrder === this.sequenceOrder &&
-      matchingArraysOfOrderedElectionObjects(other.selections, this.selections)
+      matchingArraysOfAnyElectionObjects(other.selections, this.selections)
     );
   }
 }
 
 /** The plaintext representation of one selection for a particular contest. */
-export class PlaintextSelection implements OrderedObjectBase {
+export class PlaintextSelection implements ElectionObjectBase {
   constructor(
     readonly selectionId: string, // matches SelectionDescription.selectionId
-    readonly sequenceOrder: number,
     readonly vote: number,
     readonly isPlaceholderSelection: boolean,
-    readonly extendedData?: ExtendedData
+    readonly writeIn?: string
   ) {}
 
   get objectId(): string {
@@ -69,15 +69,9 @@ export class PlaintextSelection implements OrderedObjectBase {
     return (
       other instanceof PlaintextSelection &&
       other.selectionId === this.selectionId &&
-      other.sequenceOrder === this.sequenceOrder &&
       other.vote === this.vote &&
-      other.isPlaceholderSelection === this.isPlaceholderSelection
+      other.isPlaceholderSelection === this.isPlaceholderSelection &&
+      other.writeIn === this.writeIn
     );
-    // ignoring extended data
   }
-}
-
-/** Used to indicate a write-in candidate. */
-export class ExtendedData {
-  constructor(readonly value: string, readonly length: number) {}
 }

--- a/test/electionguard/ballot/generators.ts
+++ b/test/electionguard/ballot/generators.ts
@@ -577,21 +577,11 @@ export function plaintextVotedBallot(manifest: M.Manifest) {
 
         const votedSelections = yesVotes
           .map(selectionDesc =>
-            selectionFrom(
-              selectionDesc.selectionId,
-              selectionDesc.sequenceOrder,
-              false,
-              true
-            )
+            selectionFrom(selectionDesc.selectionId, false, true)
           )
           .concat(
             noVotes.map(selectionDesc =>
-              selectionFrom(
-                selectionDesc.selectionId,
-                selectionDesc.sequenceOrder,
-                false,
-                false
-              )
+              selectionFrom(selectionDesc.selectionId, false, false)
             )
           );
         return new PlaintextContest(

--- a/test/electionguard/ballot/generators.ts
+++ b/test/electionguard/ballot/generators.ts
@@ -584,11 +584,7 @@ export function plaintextVotedBallot(manifest: M.Manifest) {
               selectionFrom(selectionDesc.selectionId, false, false)
             )
           );
-        return new PlaintextContest(
-          contest.contestId,
-          contest.sequenceOrder,
-          votedSelections
-        );
+        return new PlaintextContest(contest.contestId, votedSelections);
       });
       return new PlaintextBallot(
         ballotUuid,


### PR DESCRIPTION
- `PlaintextSelection`: remove `sequenceOrder` and replace `extendedData` with `writeIn` (string).
- `PlaintextContest`: remove `sequenceOrder`.

Sorry for the flip-flop on this, but it seems that the sequence order field has, in fact, been removed from both plaintext selections and plaintext contests (microsoft/electionguard-python#641 and microsoft/electionguard#262). I've tried to adapt `encrypt-async`, but I'm not sure if it's correct.