### PR TITLE
Fix extended data fields

### DIFF
--- a/src/electionguard/ballot/ciphertext-ballot.ts
+++ b/src/electionguard/ballot/ciphertext-ballot.ts
@@ -90,7 +90,8 @@ export class CiphertextContest
     readonly ciphertextAccumulation: ElGamalCiphertext,
     readonly cryptoHash: ElementModQ,
     readonly proof: ConstantChaumPedersenProofKnownNonce,
-    readonly contestNonce: ElementModQ
+    readonly contestNonce: ElementModQ,
+    readonly extendedData?: HashedElGamalCiphertext
   ) {}
 
   get objectId(): string {
@@ -110,6 +111,7 @@ export class CiphertextContest
       other.proof.equals(this.proof) &&
       other.contestNonce.equals(this.contestNonce)
     );
+    // ignoring extended data
   }
 
   get cryptoHashElement(): ElementModQ {
@@ -140,8 +142,7 @@ export class CiphertextSelection
     readonly cryptoHash: ElementModQ,
     readonly isPlaceholderSelection: boolean,
     readonly proof: DisjunctiveChaumPedersenProofKnownNonce,
-    readonly selectionNonce?: ElementModQ,
-    readonly extendedData?: HashedElGamalCiphertext
+    readonly selectionNonce?: ElementModQ
   ) {}
 
   get objectId(): string {
@@ -160,7 +161,6 @@ export class CiphertextSelection
       other.proof.equals(this.proof) &&
       objEqualsOrUndefEquals(other.selectionNonce, this.selectionNonce)
     );
-    // ignoring extended data
   }
 
   get cryptoHashElement(): ElementModQ {
@@ -175,8 +175,7 @@ export class CiphertextSelection
       this.ciphertext,
       this.cryptoHash,
       this.isPlaceholderSelection,
-      this.proof,
-      this.extendedData
+      this.proof
     );
   }
 }

--- a/src/electionguard/ballot/encrypt.ts
+++ b/src/electionguard/ballot/encrypt.ts
@@ -401,8 +401,7 @@ export function encryptSelection(
     cryptoHash,
     isPlaceholder,
     proof,
-    selectionNonce,
-    undefined // no extended data (yet!)
+    selectionNonce
   );
   return encryptedSelection;
 }

--- a/src/electionguard/ballot/json.ts
+++ b/src/electionguard/ballot/json.ts
@@ -723,9 +723,6 @@ export class BallotCodecs {
           nonce: D.nullable(D.string),
           is_placeholder_selection: D.boolean,
           proof: this.coreCodecs.disjunctiveChaumPedersenProofKnownNonceCodec,
-          extended_data: D.nullable(
-            this.coreCodecs.hashedElGamalCiphertextCodec
-          ),
         }),
         D.map(
           s =>
@@ -736,8 +733,7 @@ export class BallotCodecs {
               s.ciphertext,
               s.crypto_hash,
               s.is_placeholder_selection,
-              s.proof,
-              s.extended_data || undefined
+              s.proof
             )
         )
       );
@@ -760,11 +756,6 @@ export class BallotCodecs {
           this.coreCodecs.disjunctiveChaumPedersenProofKnownNonceCodec.encode(
             input.proof
           ),
-        extended_data:
-          input.extendedData &&
-          this.coreCodecs.hashedElGamalCiphertextCodec.encode(
-            input.extendedData
-          ),
       }),
     };
 
@@ -782,6 +773,7 @@ export class BallotCodecs {
         ciphertext_accumulation: this.coreCodecs.elGamalCiphertextCodec,
         crypto_hash: this.coreCodecs.elementModQCodec,
         proof: this.coreCodecs.constantChaumPedersenProofKnownNonceCodec,
+        extended_data: D.nullable(this.coreCodecs.hashedElGamalCiphertextCodec),
       }),
       D.map(
         s =>
@@ -792,7 +784,8 @@ export class BallotCodecs {
             s.ballot_selections,
             s.ciphertext_accumulation,
             s.crypto_hash,
-            s.proof
+            s.proof,
+            s.extended_data || undefined
           )
       )
     );
@@ -816,6 +809,11 @@ export class BallotCodecs {
         proof: this.coreCodecs.constantChaumPedersenProofKnownNonceCodec.encode(
           input.proof
         ),
+        extended_data:
+          input.extendedData &&
+          this.coreCodecs.hashedElGamalCiphertextCodec.encode(
+            input.extendedData
+          ),
       }),
     };
 
@@ -887,9 +885,6 @@ export class BallotCodecs {
           nonce: D.nullable(this.coreCodecs.elementModQCodec),
           is_placeholder_selection: D.boolean,
           proof: this.coreCodecs.disjunctiveChaumPedersenProofKnownNonceCodec,
-          extended_data: D.nullable(
-            this.coreCodecs.hashedElGamalCiphertextCodec
-          ),
         }),
         D.map(
           s =>
@@ -901,8 +896,7 @@ export class BallotCodecs {
               s.crypto_hash,
               s.is_placeholder_selection,
               s.proof,
-              s.nonce || undefined,
-              s.extended_data || undefined
+              s.nonce || undefined
             )
         )
       );
@@ -926,11 +920,6 @@ export class BallotCodecs {
             this.coreCodecs.disjunctiveChaumPedersenProofKnownNonceCodec.encode(
               input.proof
             ),
-          extended_data:
-            input.extendedData &&
-            this.coreCodecs.hashedElGamalCiphertextCodec.encode(
-              input.extendedData
-            ),
         }),
       };
 
@@ -950,6 +939,9 @@ export class BallotCodecs {
           crypto_hash: this.coreCodecs.elementModQCodec,
           nonce: this.coreCodecs.elementModQCodec,
           proof: this.coreCodecs.constantChaumPedersenProofKnownNonceCodec,
+          extended_data: D.nullable(
+            this.coreCodecs.hashedElGamalCiphertextCodec
+          ),
         }),
         D.map(
           s =>
@@ -961,7 +953,8 @@ export class BallotCodecs {
               s.ciphertext_accumulation,
               s.crypto_hash,
               s.proof,
-              s.nonce
+              s.nonce,
+              s.extended_data || undefined
             )
         )
       );
@@ -983,6 +976,11 @@ export class BallotCodecs {
         proof: this.coreCodecs.constantChaumPedersenProofKnownNonceCodec.encode(
           input.proof
         ),
+        extended_data:
+          input.extendedData &&
+          this.coreCodecs.hashedElGamalCiphertextCodec.encode(
+            input.extendedData
+          ),
       }),
     };
 

--- a/src/electionguard/ballot/submitted-ballot.ts
+++ b/src/electionguard/ballot/submitted-ballot.ts
@@ -56,7 +56,8 @@ export class SubmittedContest
     readonly selections: Array<SubmittedSelection>,
     readonly ciphertextAccumulation: ElGamalCiphertext,
     readonly cryptoHashElement: ElementModQ,
-    readonly proof: ConstantChaumPedersenProofKnownNonce
+    readonly proof: ConstantChaumPedersenProofKnownNonce,
+    readonly extendedData?: HashedElGamalCiphertext
   ) {}
 
   get objectId(): string {
@@ -73,6 +74,7 @@ export class SubmittedContest
       this.ciphertextAccumulation.equals(other.ciphertextAccumulation) &&
       this.proof.equals(other.proof)
     );
+    // ignoring extended data
   }
 }
 
@@ -86,8 +88,7 @@ export class SubmittedSelection
     readonly ciphertext: ElGamalCiphertext,
     readonly cryptoHashElement: ElementModQ,
     readonly isPlaceholderSelection: boolean,
-    readonly proof: DisjunctiveChaumPedersenProofKnownNonce,
-    readonly extendedData?: HashedElGamalCiphertext
+    readonly proof: DisjunctiveChaumPedersenProofKnownNonce
   ) {}
 
   get objectId(): string {
@@ -104,7 +105,6 @@ export class SubmittedSelection
       this.isPlaceholderSelection === other.isPlaceholderSelection &&
       this.proof.equals(other.proof) &&
       this.cryptoHashElement.equals(other.cryptoHashElement)
-      // ignoring extended data
     );
   }
 }


### PR DESCRIPTION
Moves the extended data fields from selections to contests, in accordance with the schemas, sample data, and current electionguard-python.