### PR TITLE
Make async elgamal work

### DIFF
--- a/src/electionguard/ballot/ciphertext-ballot.ts
+++ b/src/electionguard/ballot/ciphertext-ballot.ts
@@ -34,7 +34,7 @@ export class CiphertextBallot implements ElectionObjectBase {
     readonly contests: Array<CiphertextContest>,
     readonly timestamp: number,
     readonly cryptoHash: ElementModQ,
-    readonly masterNonce: ElementModQ
+    readonly nonce: ElementModQ
   ) {}
 
   get objectId(): string {
@@ -51,16 +51,16 @@ export class CiphertextBallot implements ElectionObjectBase {
       matchingArraysOfOrderedElectionObjects(other.contests, this.contests) &&
       other.timestamp === this.timestamp &&
       other.cryptoHash.equals(this.cryptoHash) &&
-      other.masterNonce.equals(this.masterNonce)
+      other.nonce.equals(this.nonce)
     );
   }
 
-  ballotNonce(): ElementModQ {
+  hashedBallotNonce(): ElementModQ {
     return hashElements(
-      this.masterNonce.context,
+      this.nonce.context,
       this.manifestHash,
       this.ballotId,
-      this.masterNonce
+      this.nonce
     );
   }
 

--- a/src/electionguard/core/group-bigint.ts
+++ b/src/electionguard/core/group-bigint.ts
@@ -26,6 +26,7 @@ import {
 } from './constants';
 import {UInt256} from './uint256';
 import {PowRadix} from './powradix';
+import * as log from './logging';
 
 // This file exports the functions `bigIntContext3072()` and `bigIntContext4096()`, which return
 // instances of the GroupContext interface found in group-common.ts, and which implements all
@@ -172,7 +173,11 @@ class ElementModPImpl implements ElementModP {
       this.context.Q,
       this.context.P
     );
-    return this.isInBounds() && residue === BIG_ONE;
+    const result = residue === BIG_ONE && this.isInBounds();
+    if (!result) {
+      log.warn('GroupBigInt', `invalid residue found for ${this.value}`);
+    }
+    return result;
   }
 
   isZero(): boolean {

--- a/src/electionguard/core/group-common.ts
+++ b/src/electionguard/core/group-common.ts
@@ -45,8 +45,8 @@ export interface Element extends CryptoHashableString {
 /**
  * General-purpose holder of elements in [0, Q). The constructor
  * and concrete type are not exposed. Instead use the helper
- * functions, like {@link createElementModQ}, which will check
- * for errors.
+ * functions, like {@link GroupContext[createElementModQ]},
+ * which will check for errors.
  */
 export interface ElementModQ extends Element {
   equals(other: ElementModQ): boolean;
@@ -61,8 +61,8 @@ export interface ElementModQ extends Element {
 /**
  * General-purpose holder of elements in [0, P). The constructor
  * and concrete type are not exposed. Instead use the helper
- * functions, like {@link createElementModP}, which will check
- * for errors.
+ * functions, like {@link GroupContext[createElementModP]},
+ * which will check for errors.
  */
 export interface ElementModP extends Element {
   equals(other: ElementModP): boolean;

--- a/src/electionguard/core/json.ts
+++ b/src/electionguard/core/json.ts
@@ -244,11 +244,11 @@ export class Codecs {
         crypto_base_hash: elementModQDecoder,
         crypto_extended_base_hash: elementModQDecoder,
         commitment_hash: elementModQDecoder,
-        configuration: edgeCaseConfigurationDecoder,
       }),
       D.intersect(
         D.partial({
           extended_data: D.nullable(D.record(D.string)),
+          configuration: D.nullable(edgeCaseConfigurationDecoder),
         })
       ),
       D.map(
@@ -262,10 +262,8 @@ export class Codecs {
             s.crypto_extended_base_hash,
             s.commitment_hash,
             // TODO: verify this is the way handle an optional record field
-            s.extended_data === null || s.extended_data === undefined
-              ? undefined
-              : s.extended_data,
-            s.configuration
+            s.extended_data || undefined,
+            s.configuration || undefined
           )
       )
     );
@@ -285,11 +283,11 @@ export class Codecs {
           ),
           commitment_hash: elementModQEncoder.encode(e.commitmentHash),
           // TODO: verify this is the way to handle an optional record field
-          extended_data: e.extendedData === undefined ? null : e.extendedData,
+          extended_data: e.extendedData || null,
           configuration:
-            e.configuration === undefined
-              ? null
-              : edgeCaseConfigurationEncoder.encode(e.configuration),
+            e.configuration !== undefined
+              ? edgeCaseConfigurationEncoder.encode(e.configuration)
+              : undefined,
         };
       },
     };
@@ -622,7 +620,15 @@ export function getCoreCodecsForContext(context: GroupContext): Codecs {
  */
 export function eitherRightOrFail<E, T>(input: Either.Either<E, T>): T {
   if (Either.isLeft(input)) {
-    throw new Error(`${JSON.stringify(input.left, null, 2)}`);
+    // Only printing a few lines of the text, because this can become
+    // enormous for some of the types we're working with; set a breakpoint
+    // here to inspect the data directly, if necessary.
+    throw new Error(
+      `Unexpected failure: ${JSON.stringify(input.left, null, 2).substring(
+        0,
+        200
+      )}`
+    );
   } else {
     return input.right;
   }

--- a/test/electionguard/ballot/encrypt-async.test.ts
+++ b/test/electionguard/ballot/encrypt-async.test.ts
@@ -1,5 +1,4 @@
 import fc from 'fast-check';
-import * as log from '../../../src/electionguard/core/logging';
 import {
   bigIntContext4096,
   eitherRightOrFail,
@@ -20,10 +19,10 @@ import {getBallotCodecsForContext} from '../../../src/electionguard/ballot/json'
 const groupContext = bigIntContext4096();
 
 describe('Async encryption wrapper', () => {
-  afterAll(() => {
-    console.info('After-action report for async-encryption:');
-    log.consoleAllLogs();
-  });
+  // afterAll(async () => {
+  // console.info('After-action report for async-encryption:');
+  // log.consoleAllLogs();
+  // });
 
   test('Encrypt conventionally & with async; idential result', async () => {
     fc.assert(
@@ -31,7 +30,7 @@ describe('Async encryption wrapper', () => {
         electionAndBallots(groupContext),
         elementModQ(groupContext),
         async (eb, seed) => {
-          log.info('encrypt-async-test', 'starting test');
+          // log.info('encrypt-async-test', 'starting test');
           const timestamp = Date.now() / 1000;
           const encryptionState = new EncryptionState(
             groupContext,
@@ -40,7 +39,7 @@ describe('Async encryption wrapper', () => {
             true
           );
 
-          log.info('encrypt-async-test', 'starting conventional encryption');
+          // log.info('encrypt-async-test', 'starting conventional encryption');
           const plaintextBallot = eb.ballots[0];
           const encryptedBallot = encryptBallot(
             encryptionState,
@@ -49,24 +48,24 @@ describe('Async encryption wrapper', () => {
             timestamp
           );
 
-          log.info('encrypt-async-test', 'getting codecs');
+          // log.info('encrypt-async-test', 'getting codecs');
           const bCodecs = getBallotCodecsForContext(groupContext);
           const cCodecs = getCoreCodecsForContext(groupContext);
 
-          log.info('encrypt-async-test', 'encoding manifest');
+          // log.info('encrypt-async-test', 'encoding manifest');
           const manifestJson = bCodecs.manifestCodec.encode(
             eb.manifest
           ) as object;
-          log.info('encrypt-async-test', 'encoding election context');
+          // log.info('encrypt-async-test', 'encoding election context');
           const electionContextJson = cCodecs.electionContextCodec.encode(
             eb.electionContext
           ) as object;
 
-          log.info('encrypt-async-test', 'decoding manifest');
+          // log.info('encrypt-async-test', 'decoding manifest');
           /* const manifestDecoded = */ eitherRightOrFail(
             bCodecs.manifestCodec.decode(manifestJson)
           );
-          log.info('encrypt-async-test', 'decoding election context');
+          // log.info('encrypt-async-test', 'decoding election context');
           const electionContextDecoded = eitherRightOrFail(
             cCodecs.electionContextCodec.decode(electionContextJson)
           );
@@ -75,7 +74,7 @@ describe('Async encryption wrapper', () => {
             electionContextDecoded.jointPublicKey.element.isValidResidue()
           ).toBe(true);
 
-          log.info('encrypt-async-test', 'initializing async encryption');
+          // log.info('encrypt-async-test', 'initializing async encryption');
           const asyncEncryptor = AsyncBallotEncryptor.create(
             groupContext,
             manifestJson,
@@ -87,14 +86,14 @@ describe('Async encryption wrapper', () => {
             timestamp
           );
 
-          log.info('encrypt-async-test', 'launching async encryption');
+          // log.info('encrypt-async-test', 'launching async encryption');
           // launches encryption on each contest: note the absence of return values
           plaintextBallot.contests.forEach(contest =>
             asyncEncryptor.encrypt(contest)
           );
 
           const encryptedBallot2 = await asyncEncryptor.getEncryptedBallot();
-          log.info('encrypt-async-test', 'async tasks complete');
+          // log.info('encrypt-async-test', 'async tasks complete');
 
           expect(encryptedBallot.equals(encryptedBallot2)).toBe(true);
         }

--- a/test/electionguard/ballot/encrypt-async.test.ts
+++ b/test/electionguard/ballot/encrypt-async.test.ts
@@ -45,16 +45,22 @@ describe('Async encryption wrapper', () => {
             timestamp
           );
 
+          log.info('encrypt-async-test', 'getting codecs');
           const bcodecs = getBallotCodecsForContext(groupContext);
           const ecodecs = getCoreCodecsForContext(groupContext);
+
+          log.info('encrypt-async-test', 'encoding manifest');
           const manifestJson = bcodecs.manifestCodec.encode(
             eb.manifest
           ) as object;
+          log.info('encrypt-async-test', 'encoding election context');
           const electionContextJson = ecodecs.electionContextCodec.encode(
             eb.electionContext
           ) as object;
 
+          log.info('encrypt-async-test', 'decoding manifest');
           const manifestDecoded = bcodecs.manifestCodec.decode(manifestJson);
+          log.info('encrypt-async-test', 'decoding election context');
           const electionContextDecoded =
             ecodecs.electionContextCodec.decode(electionContextJson);
           expect(Either.isRight(manifestDecoded)).toBeTruthy();

--- a/test/electionguard/ballot/encrypt.test.ts
+++ b/test/electionguard/ballot/encrypt.test.ts
@@ -159,7 +159,7 @@ describe('Election / ballot encryption', () => {
           );
 
           const ballotNonces: bigint[] = encryptedBallots.map(ballot =>
-            ballot.ballotNonce().toBigint()
+            ballot.nonce.toBigint()
           );
 
           const allBallotNonces = selectionNonces

--- a/test/electionguard/ballot/json.test.ts
+++ b/test/electionguard/ballot/json.test.ts
@@ -3,9 +3,10 @@ import {bigIntContext3072} from '../../../src/electionguard/core/group-bigint';
 import {getBallotCodecsForContext} from '../../../src/electionguard/ballot/json';
 import {testCodecLaws} from '../core/testCodecLaws';
 import * as G from './generators';
+import {getCoreCodecsForContext} from '../../../src/electionguard';
 
 function testBallotCodecsForContext(context: GroupContext) {
-  //   const cCodecs = getCoreCodecsForContext(context);
+  const cCodecs = getCoreCodecsForContext(context);
   const bCodecs = getBallotCodecsForContext(context);
   testCodecLaws(
     context.name,
@@ -115,6 +116,16 @@ function testBallotCodecsForContext(context: GroupContext) {
     G.electionDescription(context),
     bCodecs.manifestCodec,
     (a, b) => a.equals(b)
+  );
+  testCodecLaws(
+    context.name,
+    'ElectionContext',
+    G.electionAndBallots(context, 1).map(eb => eb.electionContext),
+    cCodecs.electionContextCodec,
+    (a, b) =>
+      a.equals(b) &&
+      a.jointPublicKey.element.isValidResidue() &&
+      b.jointPublicKey.element.isValidResidue()
   );
 }
 

--- a/test/electionguard/core/testCodecLaws.ts
+++ b/test/electionguard/core/testCodecLaws.ts
@@ -4,6 +4,7 @@ import * as fc from 'fast-check';
 import {fcFastConfig} from './generators';
 import {eitherRightOrFail} from '../../../src/electionguard/core/json';
 import * as Either from 'fp-ts/lib/Either';
+import * as log from '../../../src/electionguard/core/logging';
 
 /** Evaluates any codec and generator for correctness. */
 export function testCodecLaws<T>(
@@ -20,7 +21,10 @@ export function testCodecLaws<T>(
           const serialized = codec.encode(value);
           const deserialized = codec.decode(serialized);
           if (Either.isLeft(deserialized)) {
-            console.warn(`deserialization failure for ${typeName}`);
+            log.warn(
+              'testCodecLaws',
+              `deserialization failure for ${typeName}`
+            );
           }
 
           const unpacked = eitherRightOrFail(deserialized);
@@ -31,7 +35,8 @@ export function testCodecLaws<T>(
           try {
             serializedStr = JSON.stringify(serialized);
           } catch (e: unknown) {
-            console.warn(
+            log.warn(
+              'testCodecLaws',
               `unexpected JSON stringify failure for ${typeName}: ${serialized}`
             );
             throw e;

--- a/test/electionguard/core/testCodecLaws.ts
+++ b/test/electionguard/core/testCodecLaws.ts
@@ -30,7 +30,7 @@ export function testCodecLaws<T>(
           let serializedStr;
           try {
             serializedStr = JSON.stringify(serialized);
-          } catch (e: any) {
+          } catch (e: unknown) {
             console.warn(
               `unexpected JSON stringify failure for ${typeName}: ${serialized}`
             );


### PR DESCRIPTION
Lots of effort to get async encryption working, but now it all seems happy. Some of the nasty problems included:
- mixing and matching of the 3072 and 4096-bit groups (initially presented itself as a deserialization issue, which dragged me wildly off track before isolating the problem)
- using the wrong value for the `nonce` field of the `CiphertextBallot`
- renamed a few class members to be more consistent with their Python equivalents
- our logging subsystem was invaluable, but for some reason the `afterAll` part was executing before the tests were complete, resulting in some complaints from Jest. (Why? Unclear.)

I'm nowhere near sure that we're bug-for-bug compatible with the Python code, but at least we're kinda sorta actually working.