### PR TITLE
Dealing with missing contests and selections

### DIFF
--- a/src/electionguard/ballot/encrypt.ts
+++ b/src/electionguard/ballot/encrypt.ts
@@ -7,7 +7,7 @@ import {elGamalAdd, elGamalEncrypt, ElGamalPublicKey} from '../core/elgamal';
 import {addQ, ElementModQ, GroupContext} from '../core/group-common';
 import {hashElements} from '../core/hash';
 import {Nonces} from '../core/nonces';
-import {associateBy, maxOf, numberRange, stringSetsEqual} from '../core/utils';
+import {associateBy, maxOf, numberRange} from '../core/utils';
 import {
   CiphertextBallot,
   CiphertextContest,
@@ -22,6 +22,8 @@ import {
   PlaintextBallot,
   PlaintextContest,
   PlaintextSelection,
+  normalizeBallot,
+  normalizeContest,
   selectionFrom,
 } from './plaintext-ballot';
 import * as log from '../core/logging';
@@ -82,19 +84,10 @@ export function encryptBallot(
     ballotEncryptionSeed
   );
 
-  const normalizedBallot = ballot.normalize(state.manifest);
+  const normalizedBallot = normalizeBallot(ballot, state.manifest);
   const contestsForStyle = state.manifest.getContests(
     normalizedBallot.ballotStyleId
   );
-
-  if (
-    !stringSetsEqual(
-      normalizedBallot.contests.map(c => c.contestId),
-      contestsForStyle.map(c => c.contestId)
-    )
-  ) {
-    throw new Error('Ballot has missing or extraneous contests');
-  }
 
   const pcontests = associateBy(normalizedBallot.contests, c => c.contestId);
   const encryptedContests = contestsForStyle.map(mcontest => {
@@ -169,7 +162,7 @@ export function encryptContest(
   const contestNonce = nonceSequence.get(contestDescription.sequenceOrder);
   const chaumPedersenNonce = nonceSequence.get(0);
 
-  const normalizedContest = contest.normalize(contestDescription);
+  const normalizedContest = normalizeContest(contest, contestDescription);
   const plaintextSelections = associateBy(
     normalizedContest.selections,
     s => s.selectionId

--- a/src/electionguard/ballot/encrypt.ts
+++ b/src/electionguard/ballot/encrypt.ts
@@ -86,9 +86,11 @@ export function encryptBallot(
   const encryptedContests = state.manifest
     .getContests(ballot.ballotStyleId)
     .map(mcontest => {
-      const pcontest: PlaintextContest =
-        pcontests.get(mcontest.contestId) ?? contestFrom(mcontest);
-      // If no contest on the ballot, create a placeholder
+      const pcontest = pcontests.get(mcontest.contestId);
+      if (pcontest === undefined) {
+        throw new Error(`Missing contest: ${mcontest.contestId}`);
+      }
+
       return encryptContest(
         state,
         pcontest,
@@ -128,13 +130,6 @@ export function encryptBallot(
     ballotEncryptionSeed
   );
   return encryptedBallot;
-}
-
-function contestFrom(mcontest: ManifestContestDescription): PlaintextContest {
-  const selections = mcontest.selections.map(it =>
-    selectionFrom(it.selectionId, false, false)
-  );
-  return new PlaintextContest(mcontest.contestId, selections);
 }
 
 /**

--- a/test/electionguard/ballot/encrypt.test.ts
+++ b/test/electionguard/ballot/encrypt.test.ts
@@ -61,7 +61,10 @@ describe('Election / ballot encryption', () => {
           );
 
           expect(
-            matchingArraysOfAnyElectionObjects(eb.ballots, decryptedBallots)
+            matchingArraysOfAnyElectionObjects(
+              eb.ballots.map(ballot => ballot.normalize(eb.manifest)),
+              decryptedBallots
+            )
           ).toBe(true);
         }
       ),

--- a/test/electionguard/ballot/encrypt.test.ts
+++ b/test/electionguard/ballot/encrypt.test.ts
@@ -311,6 +311,39 @@ describe('Election / ballot encryption', () => {
       fcFastConfig
     );
   });
+  test('Ballots with missing contests result in errors', () => {
+    fc.assert(
+      fc.property(
+        electionAndBallots(groupContext),
+        elementModQ(groupContext),
+        elementModQ(groupContext),
+        (eb, prev, seed) => {
+          const nonces = new Nonces(seed);
+          const encryptionState = new EncryptionState(
+            groupContext,
+            eb.manifest,
+            eb.electionContext,
+            true
+          );
+          const ballotsMissingContests = eb.ballots.map(
+            ballot =>
+              new PlaintextBallot(
+                ballot.ballotId,
+                ballot.ballotStyleId,
+                ballot.contests.slice(1)
+              )
+          );
+
+          ballotsMissingContests.forEach((b, i) => {
+            expect(() =>
+              encryptBallot(encryptionState, b, prev, nonces.get(i))
+            ).toThrow();
+          });
+        }
+      ),
+      fcFastConfig
+    );
+  });
 });
 
 function noRepeatingBigints(input: bigint[]): boolean {

--- a/test/electionguard/ballot/generators.ts
+++ b/test/electionguard/ballot/generators.ts
@@ -8,8 +8,8 @@ import {
   PlaintextContest,
   EncryptionState,
 } from '../../../src/electionguard';
-import {selectionFrom} from '../../../src/electionguard/ballot/encrypt';
 import * as M from '../../../src/electionguard/ballot/manifest';
+import {selectionFrom} from '../../../src/electionguard/ballot/plaintext-ballot';
 import {
   chunkArray,
   numberRange,

--- a/test/electionguard/ballot/generators.ts
+++ b/test/electionguard/ballot/generators.ts
@@ -635,45 +635,57 @@ export function plaintextVotedBallot(manifest: M.Manifest) {
   }
 
   return fc
-    .tuple(
-      fc.uuid(),
-      fc
-        .constantFrom(...manifest.ballotStyles)
-        .filter(bs => manifest.getContests(bs.ballotStyleId).length >= 1),
-      fc.string()
-    )
-    .map(t => {
-      const [ballotUuid, ballotStyle, rngSeed] = t;
-      const rng = seedrandom(rngSeed);
-      const contests = manifest.getContests(ballotStyle.ballotStyleId);
+    .constantFrom(...manifest.ballotStyles)
+    .filter(bs => manifest.getContests(bs.ballotStyleId).length >= 1)
+    .chain(ballotStyle => {
+      return fc
+        .tuple(
+          fc.shuffledSubarray(manifest.getContests(ballotStyle.ballotStyleId), {
+            minLength: 1,
+          }),
+          fc.uuid(),
+          fc.string()
+        )
+        .map(t => {
+          const [contests, ballotUuid, rngSeed] = t;
+          const rng = seedrandom(rngSeed);
 
-      const votedContests = contests.map(contest => {
-        if (!contest.isValid()) {
-          throw new Error(`contest isn't valid?: ${contest}`);
-        }
-        const n = contest.numberElected;
-        const ballotSelections = contest.selections;
-        const randomSelections = shuffleArray(ballotSelections, rng);
-        const cutPoint = rng.int32() % n;
-        const yesVotes = randomSelections.slice(0, cutPoint);
-        const noVotes = randomSelections.slice(cutPoint);
+          const votedContests = contests.map(contest => {
+            if (!contest.isValid()) {
+              throw new Error(`contest isn't valid?: ${contest}`);
+            }
+            const n = contest.numberElected;
+            const ballotSelections = contest.selections;
+            const randomSelections = shuffleArray(ballotSelections, rng);
+            const cutPoint = rng.int32() % n;
+            const yesVotes = randomSelections.slice(0, cutPoint);
+            const noVotes = randomSelections.slice(cutPoint);
+            const noVotesSubset = noVotes.slice(
+              0,
+              rng.int32() % (noVotes.length + 1)
+            );
 
-        const votedSelections = yesVotes
-          .map(selectionDesc =>
-            selectionFrom(selectionDesc.selectionId, false, true)
-          )
-          .concat(
-            noVotes.map(selectionDesc =>
-              selectionFrom(selectionDesc.selectionId, false, false)
-            )
+            const votedSelections = yesVotes
+              .map(selectionDesc =>
+                selectionFrom(selectionDesc.selectionId, false, true)
+              )
+              .concat(
+                noVotesSubset.map(selectionDesc =>
+                  selectionFrom(selectionDesc.selectionId, false, false)
+                )
+              );
+            return new PlaintextContest(
+              contest.contestId,
+              shuffleArray(votedSelections, rng)
+            );
+          });
+
+          return new PlaintextBallot(
+            ballotUuid,
+            ballotStyle.ballotStyleId,
+            votedContests // already shuffled
           );
-        return new PlaintextContest(contest.contestId, votedSelections);
-      });
-      return new PlaintextBallot(
-        ballotUuid,
-        ballotStyle.ballotStyleId,
-        votedContests
-      );
+        });
     });
 }
 

--- a/test/electionguard/ballot/generators.ts
+++ b/test/electionguard/ballot/generators.ts
@@ -638,47 +638,54 @@ export function plaintextVotedBallot(manifest: M.Manifest) {
     .constantFrom(...manifest.ballotStyles)
     .filter(bs => manifest.getContests(bs.ballotStyleId).length >= 1)
     .chain(ballotStyle => {
-      return fc.tuple(fc.uuid(), fc.string()).map(t => {
-        const [ballotUuid, rngSeed] = t;
-        const contests = manifest.getContests(ballotStyle.ballotStyleId);
-        const rng = seedrandom(rngSeed);
+      return fc
+        .tuple(
+          fc.shuffledSubarray(manifest.getContests(ballotStyle.ballotStyleId), {
+            minLength: 1,
+          }),
+          fc.uuid(),
+          fc.string()
+        )
+        .map(t => {
+          const [contests, ballotUuid, rngSeed] = t;
+          const rng = seedrandom(rngSeed);
 
-        const votedContests = contests.map(contest => {
-          if (!contest.isValid()) {
-            throw new Error(`contest isn't valid?: ${contest}`);
-          }
-          const n = contest.numberElected;
-          const ballotSelections = contest.selections;
-          const randomSelections = shuffleArray(ballotSelections, rng);
-          const cutPoint = rng.int32() % n;
-          const yesVotes = randomSelections.slice(0, cutPoint);
-          const noVotes = randomSelections.slice(cutPoint);
-          const noVotesSubset = noVotes.slice(
-            0,
-            rng.int32() % (noVotes.length + 1)
-          );
-
-          const votedSelections = yesVotes
-            .map(selectionDesc =>
-              selectionFrom(selectionDesc.selectionId, false, true)
-            )
-            .concat(
-              noVotesSubset.map(selectionDesc =>
-                selectionFrom(selectionDesc.selectionId, false, false)
-              )
+          const votedContests = contests.map(contest => {
+            if (!contest.isValid()) {
+              throw new Error(`contest isn't valid?: ${contest}`);
+            }
+            const n = contest.numberElected;
+            const ballotSelections = contest.selections;
+            const randomSelections = shuffleArray(ballotSelections, rng);
+            const cutPoint = rng.int32() % n;
+            const yesVotes = randomSelections.slice(0, cutPoint);
+            const noVotes = randomSelections.slice(cutPoint);
+            const noVotesSubset = noVotes.slice(
+              0,
+              rng.int32() % (noVotes.length + 1)
             );
-          return new PlaintextContest(
-            contest.contestId,
-            shuffleArray(votedSelections, rng)
+
+            const votedSelections = yesVotes
+              .map(selectionDesc =>
+                selectionFrom(selectionDesc.selectionId, false, true)
+              )
+              .concat(
+                noVotesSubset.map(selectionDesc =>
+                  selectionFrom(selectionDesc.selectionId, false, false)
+                )
+              );
+            return new PlaintextContest(
+              contest.contestId,
+              shuffleArray(votedSelections, rng)
+            );
+          });
+
+          return new PlaintextBallot(
+            ballotUuid,
+            ballotStyle.ballotStyleId,
+            votedContests // already shuffled
           );
         });
-
-        return new PlaintextBallot(
-          ballotUuid,
-          ballotStyle.ballotStyleId,
-          votedContests // already shuffled
-        );
-      });
     });
 }
 

--- a/test/electionguard/ballot/plaintext-ballot.test.ts
+++ b/test/electionguard/ballot/plaintext-ballot.test.ts
@@ -4,6 +4,7 @@ import {
   PlaintextBallot,
   PlaintextContest,
 } from '../../../src/electionguard';
+import {normalizeBallot} from '../../../src/electionguard/ballot/plaintext-ballot';
 import {shuffleArray} from '../../../src/electionguard/core/utils';
 import {fcFastConfig} from '../core/generators';
 import {electionAndBallots} from './generators';
@@ -37,7 +38,7 @@ describe('Plaintext ballots', () => {
     fc.assert(
       fc.property(electionAndBallots(groupContext, 1), eb => {
         const [ballot] = eb.ballots;
-        const normalizedBallot = ballot.normalize(eb.manifest);
+        const normalizedBallot = normalizeBallot(ballot, eb.manifest);
 
         normalizedBallot.contests.forEach(contest => {
           const mcontest = eb.manifest.getContest(contest.contestId);
@@ -56,9 +57,10 @@ describe('Plaintext ballots', () => {
       fc.property(electionAndBallots(groupContext, 1), eb => {
         const [ballot] = eb.ballots;
         expect(
-          ballot
-            .normalize(eb.manifest)
-            .equals(ballot.normalize(eb.manifest).normalize(eb.manifest))
+          normalizeBallot(
+            normalizeBallot(ballot, eb.manifest),
+            eb.manifest
+          ).equals(normalizeBallot(ballot, eb.manifest))
         ).toBe(true);
       }),
       fcFastConfig

--- a/test/electionguard/ballot/plaintext-ballot.test.ts
+++ b/test/electionguard/ballot/plaintext-ballot.test.ts
@@ -31,4 +31,29 @@ describe('Plaintext ballots', () => {
       })
     );
   });
+
+  test('Normalization works', () => {
+    fc.assert(
+      fc.property(electionAndBallots(groupContext, 1), eb => {
+        const [ballot] = eb.ballots;
+        expect(
+          ballot.normalize(eb.manifest).contests.map(c => c.contestId)
+        ).toStrictEqual(
+          eb.manifest.getContests(ballot.ballotStyleId).map(c => c.contestId)
+        );
+      })
+    );
+
+    // idempotent
+    fc.assert(
+      fc.property(electionAndBallots(groupContext, 1), eb => {
+        const [ballot] = eb.ballots;
+        expect(
+          ballot
+            .normalize(eb.manifest)
+            .equals(ballot.normalize(eb.manifest).normalize(eb.manifest))
+        ).toBe(true);
+      })
+    );
+  });
 });


### PR DESCRIPTION
I first noticed this a couple weeks ago when I was working on expanding our test suite. The 'sync-async identical' test fails when ballots with missing contests come into the picture. The sync version auto-adds a contest full of placeholders, but the async version gets the contests from the ballots instead of getting them from the manifest, so it doesn't do such a thing. We could adjust either to do the other. @danwallach I'd appreciate your input.

Also, to get the 'encryption/decryption inverses' test to pass, I had to slightly adjust the definition of plaintext ballot/contest equality. It raises interesting questions about whether implicitly false, explicitly false, and placeholder false selections are equivalent; I went with "they're all equivalent".

Fixes #39