### PR TITLE
Add docs deployment action

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,38 @@
+name: Build and deploy docs
+
+on:
+  push:
+    branches: ["main"]
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+    - run: npm install
+    - run: npm run docs
+    - uses: actions/configure-pages@v2
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: 'docs'
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v1


### PR DESCRIPTION
Fixes #43.

Just set up a little GH pages site for ricesec and thought I'd add this in. Tested it with my fork and it looks [like this](https://shreyasminocha.github.io/egts/). Merging the PR should do everything automatically and deploy to `/ElectionGuard-TypeScript` once a public `danwallach/danwallach.github.io` repo exists.

Does this:

> every commit updates a static GitHub Pages site.

…but not this:

> only do this if the unit tests pass